### PR TITLE
Add support for headless libs-back backend

### DIFF
--- a/patches/gnustep-back-remove-tools.patch
+++ b/patches/gnustep-back-remove-tools.patch
@@ -1,0 +1,13 @@
+diff --git a/GNUmakefile b/GNUmakefile
+index 03ad17f..029a521 100644
+--- a/GNUmakefile
++++ b/GNUmakefile
+@@ -47,7 +47,7 @@ include ./Version
+ #
+ # The list of subproject directories
+ #
+-SUBPROJECTS = Source Tools
++SUBPROJECTS = Source
+ 
+ ifneq ($(fonts), no)
+ SUBPROJECTS += Fonts

--- a/phases/51-gnustep-back.sh
+++ b/phases/51-gnustep-back.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+set -eo pipefail
+shopt -s inherit_errexit
+
+cd `dirname $0`
+
+export PROJECT=gnustep-back
+export GITHUB_REPO=gnustep/libs-back
+export TAG=
+
+# load environment and prepare project
+../scripts/common.bat prepare_project
+
+cd "$SRCROOT/$PROJECT"
+
+echo
+echo "### Loading GNUstep environment"
+. "$UNIX_INSTALL_PREFIX/share/GNUstep/Makefiles/GNUstep.sh"
+
+echo
+echo "### Running configure"
+
+./configure \
+    --enable-graphics=headless \
+    --enable-server=headless \
+    --without-freetype \
+    --host=$TARGET \
+    CFLAGS="-Wno-int-conversion"
+
+echo
+echo "### Building"
+make -j`nproc`
+
+echo
+echo "### Installing"
+make install


### PR DESCRIPTION
We're in a much better place to start building libs-back for the msvc toolchain now that gnustep/libs-gui#177 and gnustep/libs-gui#179 have been merged.

This PR starts building libs-back for msvc.  It doesn't build the full Win32 backend, but relies on a headless backend instead, which is hopefully coming via gnustep/libs-back#42.  This PR is probably blocked until that lands; but opening it for visibility.

Supporting the full Win32 backend would require additional fixes and could come in a follow-up PR.