### PR TITLE
Initial Windows on ARM64 SDK Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 .vs/
 Debug/
 Release/
+
+# VIM
+*.swp

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [![CI](https://github.com/gnustep/tools-windows-msvc/actions/workflows/ci.yml/badge.svg)](https://github.com/gnustep/tools-windows-msvc/actions/workflows/ci.yml?query=branch%3Amaster)
 
-This project comprises a collection of scripts to build a modern GNUstep toolchain, with support for blocks and Automatic Reference Counting (ARC), using LLVM/Clang and the Visual Studio toolchain. The toolchain can be used to integrate Objective-C code in any Windows app, including Visual Studio projects using LLVM/Clang (see below), without using MinGW.
+This project comprises a collection of scripts to build a modern GNUstep toolchain for x64 or arm64 architectures using the Visual Studio toolchain and LLVM/Clang. The toolchain supports Objective-C 2.0 features like blocks and Automatic Reference Counting (ARC) and can be used to integrate Objective-C code in any native Windows app — including Visual Studio projects — using LLVM/Clang (without using MinGW).
 
 
 ## Libraries
@@ -129,13 +129,13 @@ Place a breakpoint at the line `NSLog(@"Hello Objective-C");` and run from Visua
 
 ## Status and Known Issues
 
-* The toolchain supports x64 only (due to a [build error](https://bugs.swift.org/browse/SR-14314) in libdispatch on x86).
-
 * Older Clang releases had various issues with Objective-C code on Windows, most of which were fixed with Clang 16. It is therefore highly recommended to use Clang 16 or later.
   - Exception handling with ARC causing access violation ([issue](https://github.com/gnustep/libobjc2/issues/222), fixed in Clang 15)
   - Certain Objective-C++ code crashing Clang ([issue](https://github.com/llvm/llvm-project/issues/54556), affects Clang 14, fixed in Clang 15)
   - Objective-C class methods not working with ARC ([issue](https://github.com/llvm/llvm-project/issues/56952), affects Clang 14, fixed in Clang 16)
   - Using `@finally` crashing Clang ([issue 1](https://github.com/llvm/llvm-project/issues/43828) and [2](https://github.com/llvm/llvm-project/issues/51899), not fixed)
+
+* Support for x86 is broken due to a [build error](https://bugs.swift.org/browse/SR-14314) in libdispatch.
 
 * The compilation will fail if the Windows home folder contains whitespace, e.g. `C:\Users\John Appleseed`.
 
@@ -205,7 +205,7 @@ Please make sure that you do _not_ have `gmake` installed in your MSYS2 environm
 
 ### Building
 
-Run the [build.bat](build.bat) script in either a x86 or x64 Native Tools Command Prompt from Visual Studio to build the toolchain for x86 or x64.
+Run the [build.bat](build.bat) script in a x86, x64, or arm64 Native Tools Command Prompt from Visual Studio to build the toolchain for x86/x64/arm64.
 
 ```
 Usage: build.bat

--- a/patches/libdispatch-fix-woa-detection.patch
+++ b/patches/libdispatch-fix-woa-detection.patch
@@ -1,0 +1,15 @@
+https://github.com/apple/swift-corelibs-libdispatch/pull/803
+---
+diff --git a/cmake/modules/DispatchWindowsSupport.cmake b/cmake/modules/DispatchWindowsSupport.cmake
+index 87675a7..750b3be 100644
+--- a/cmake/modules/DispatchWindowsSupport.cmake
++++ b/cmake/modules/DispatchWindowsSupport.cmake
+@@ -6,7 +6,7 @@ function(dispatch_windows_arch_spelling arch var)
+     set(${var} x64 PARENT_SCOPE)
+   elseif(${arch} STREQUAL armv7)
+     set(${var} arm PARENT_SCOPE)
+-  elseif(${arch} STREQUAL aarch64)
++  elseif(${arch} STREQUAL aarch64 OR ${arch} STREQUAL ARM64)
+     set(${var} arm64 PARENT_SCOPE)
+   else()
+     message(FATAL_ERROR "do not know MSVC spelling for ARCH: `${arch}`")

--- a/phases/13-libffi.sh
+++ b/phases/13-libffi.sh
@@ -31,6 +31,9 @@ if [ "$ARCH" == "x86" ]; then
 elif [ "$ARCH" == "x64" ]; then
   MSVCC="$MSVCC -m64"
   TARGET=x86_64-pc-cygwin
+elif [ "$ARCH" == "arm64" ]; then
+  MSVCC="$MSVCC -marm64"
+  TARGET=aarch64-pc-cygwin
 else
   echo Unknown ARCH: $ARCH && exit 1
 fi

--- a/phases/14-libiconv.bat
+++ b/phases/14-libiconv.bat
@@ -19,6 +19,11 @@ if "%VSVERSION%" == "" (
   exit /b 1
 )
 
+:: ARM-based builds have a different build configuration
+if "%ARCH%" == "arm64" (
+  set VSVERSION=%VSVERSION%-arm
+)
+
 cd "%SRCROOT%\%PROJECT%\build-VS%VSVERSION%" || exit /b 1
 
 if "%ARCH%" == "x86" (
@@ -27,6 +32,9 @@ if "%ARCH%" == "x86" (
 ) else if "%ARCH%" == "x64" (
   set BUILD_DIR=x64\%BUILD_TYPE%
   set PLATFORM=x64
+) else if "%ARCH%" == "arm64" (
+  set BUILD_DIR=ARM64\%BUILD_TYPE%
+  set PLATFORM=ARM64
 ) else (
   echo Unknown ARCH: %ARCH%
   exit /b 1

--- a/phases/42-libpng.bat
+++ b/phases/42-libpng.bat
@@ -3,7 +3,13 @@ setlocal
 
 set PROJECT=libpng
 set GITHUB_REPO=glennrp/libpng
-set TAG=v1.6.39
+
+:: get the latest release tag from GitHub (DISABLED UNTIL v1.7.0 with WoA support has been released)
+::cd %~dp0
+::for /f "usebackq delims=" %%i in (`call %BASH% '../scripts/get-latest-github-release-tag.sh %GITHUB_REPO%'`) do (
+::  set TAG=%%i
+::)
+set TAG=master
 
 :: load environment and prepare project
 call "%~dp0\..\scripts\common.bat" prepare_project || exit /b 1

--- a/scripts/get-latest-github-release-tag.sh
+++ b/scripts/get-latest-github-release-tag.sh
@@ -18,10 +18,11 @@ fi
 
 # get the tags JSON from the GitHub API and parse it manually,
 # or output it to stderr if the server returns an error
+# per_page=100 is required for some repositories with a lot of beta tags
 github_tags=`curl \
   --silent --show-error --fail-with-body \
   --header "$GITHUB_AUTHORIZATION_HEADER" \
-  https://api.github.com/repos/$GITHUB_REPO/tags`
+  https://api.github.com/repos/$GITHUB_REPO/tags?per_page=100`
 
 if [ $? -eq 0 ]; then
   echo "$github_tags" \

--- a/scripts/sdkenv.bat
+++ b/scripts/sdkenv.bat
@@ -31,6 +31,9 @@ if "%ARCH%" == "x86" (
 ) else if "%ARCH%" == "x64" (
   set TARGET=x86_64-pc-windows
   set MFLAG=-m64
+) else if "%ARCH%" == "arm64" (
+  set TARGET=aarch64-pc-windows
+  set MFLAG=-m64
 ) else (
   echo Unknown target architecture: %ARCH%
   exit /b 1


### PR DESCRIPTION
This pull request adds initial support for the Windows on ARM platform.

The following build dependencies are required:
- MSVC ARM64 > 14.33 as it appears to not have `armasm64.exe` required by libffi
- A native ARM64 CMake installation

My Visual Studio Configuration for reference (17.9.0 Preview 1.1):
<img width="1457" alt="image" src="https://github.com/gnustep/tools-windows-msvc/assets/45601940/bf852d51-c065-4917-b833-eeb14fb622d9">

There are two pending pull requests, which fix some build system configuration issues:
- https://github.com/glennrp/libpng/pull/503 (Edit 20231207: Maintainer made more general fixes. Now in Upstream!)
- https://github.com/apple/swift-corelibs-libdispatch/pull/803

Merged Pull Requests:
- https://github.com/gnustep/libobjc2/pull/249

I have included the libdispatch patch, but it would be better to wait until the PR is merged.