### PR TITLE
Only build GUI when instructed with `--with-gui`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@ The toolchain consists of the following libraries:
 - [libxslt](https://github.com/GNOME/libxslt)
 - [libcurl](https://github.com/curl/curl)
 
+Optionally, GNUstep GUI (AppKit) and its dependencies can be compiled by
+setting `--with-gui`. Please note that AppKit support is experimental.
+
+- [GNUstep GUI Library](https://github.com/GNUstep/libs-gui) (AppKit)
+- [GNUstep Back Library](https://github.com/GNUstep/libs-back)
+- [GNUstep Systempreferences](https://github.com/GNUstep/apps-systempreferences)
+- [zlib-ng](https://github.com/zlib-ng/zlib-ng)
+- [libpng](https://github.com/glennrp/libpng)
+- [libtiff](https://github.com/libtiff/libtiff)
+- [libjpeg](https://github.com/libjpeg-turbo/libjpeg-turbo)
+
 
 ## Installation
 

--- a/build.bat
+++ b/build.bat
@@ -28,7 +28,7 @@ set "ROOT_DIR=%~dp0"
   if /i "%~1" == "--no-clean" set NO_CLEAN=1 & shift & goto getopts
   if /i "%~1" == "--no-update" set NO_UPDATE=1 & shift & goto getopts
   if /i "%~1" == "--patches" set "ADDITIONAL_PATCHES_DIR=%~2" & shift & shift & goto getopts
-  if /i "%~1" == "--no-gui" set NO_GUI=1 & shift & goto getopts
+  if /i "%~1" == "--with-gui" set WITH_GUI=1 & shift & goto getopts
   
   if not "%~1" == "" echo Unknown option: %~1 & exit 1
 
@@ -153,7 +153,7 @@ goto :eof
       if defined PHASE_IS_DEPENDENCY (
         call :build_phase
       )
-    ) else if not defined NO_GUI (
+    ) else if defined WITH_GUI (
       call :build_phase
     ) else if !PHASE_NUMBER! LEQ 40 (
       call :build_phase
@@ -215,7 +215,7 @@ goto :eof
   echo   --no-clean               Skip the repository cleanup operation
   echo   --no-update              Skip the repository update operation
   echo   --patches DIR            Apply additional patches from given directory
-  echo   --no-gui                 Skip gnustep-gui and related libraries
+  echo   --with-gui               Build gnustep-gui and related libraries
   echo   -h, --help, /?           Print usage information and exit
   exit 1
 


### PR DESCRIPTION
Currently, GNUstep GUI and its dependencies are always build unless explicitly disabled with `--no-gui`.

This commit changes this. User now have to explicitly enable GUI support.